### PR TITLE
Update for OpenBSD's new man.openbsd.org site

### DIFF
--- a/mdoc.su.nginx.conf
+++ b/mdoc.su.nginx.conf
@@ -144,7 +144,7 @@ Or, if you will,
 		return	404;
 	}
 	location ^~ /o {
-		set	$ob	"http://www.openbsd.org/cgi-bin/man.cgi?query=";
+		set	$ob	"http://man.openbsd.org/?query=";
 		set	$os	"&sektion=";
 		rewrite	^/o([2-9])([0-9])([,/].*)?$	/openbsd-$1.$2$3;
 		rewrite	"^/openbsd[ -/](?<or>[0-9]+(\.[0-9]+))([,/].*)?$"	/.$3;


### PR DESCRIPTION
OpenBSD moved their man pages to man.openbsd.org. All requests to the previous URL redirect to man.openbsd.org/, leaving mdoc.su users looking at a landing page instead of their query results. This PR updates the URL.
